### PR TITLE
Adding function to get path to data files

### DIFF
--- a/magic_conch/__init__.py
+++ b/magic_conch/__init__.py
@@ -1,5 +1,12 @@
 from pkg_resources import get_distribution, DistributionNotFound
+
 try:
     __version__ = get_distribution(__name__).version
+
 except DistributionNotFound:
     pass  # package is not installed
+
+else:
+    __all__ = ["get_data_filename"]
+
+    from .load_data import get_data_filename

--- a/magic_conch/functions/add_catalog.py
+++ b/magic_conch/functions/add_catalog.py
@@ -8,7 +8,10 @@ import pylab
 import seaborn as sns
 #import dask
 from tqdm import tqdm
-nova_EB = pd.read_csv('~/binary_planet_host_project/data/QVFlk0YH')
+
+from magic_conch import get_data_filename
+
+nova_EB = pd.read_csv(get_data_filename('QVFlk0YH'))
 EB_KIC = pd.DataFrame(nova_EB[['KIC','period']])
 
 def addEBCatalog(data):

--- a/magic_conch/load_data.py
+++ b/magic_conch/load_data.py
@@ -1,0 +1,10 @@
+__all__ = ["get_data_filename"]
+
+import os
+import pkg_resources
+
+
+def get_data_filename(filename):
+    return pkg_resources.resource_filename(
+        __name__, os.path.join("data", filename)
+    )


### PR DESCRIPTION
In order to avoid rigid file names, this adds a function that will always return the path to the local data files. For example:

```python
import magic_conch
print(magic_conch.get_data_filename("QVFlk0YH"))
```

prints

```python
/path/to/installed/project/or/repo/checkout/magic_conch/data/QVFlk0YH
```